### PR TITLE
queueReady should be a boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var Queue = function (queueReady) {
   var queue = [];
-  var queueReady = queueReady | false;
+  var queueReady = !!queueReady;
   var self = this;
 
   this.push = function (fn, callback, resolveImmediate) {


### PR DESCRIPTION
A single pipe character turns the lefthand side into a 32-bit integer and then OR it with the right hand side, resulting in an error. I believe that the intended action was to turn it into a boolean.
